### PR TITLE
Sets michael-rapp:java-util as an api dependency - Fixes #8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ repositories {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$version_kotlin"
-    implementation "com.github.michael-rapp:java-util:$version_java_util"
+    api "com.github.michael-rapp:java-util:$version_java_util"
     implementation "org.slf4j:slf4j-api:$version_slf4j"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$version_kotlin"
     testImplementation "org.mockito:mockito-core:$version_mockito"


### PR DESCRIPTION
> The api configuration should be used to declare dependencies which are exported by the library API, whereas the implementation configuration should be used to declare dependencies which are internal to the component. 

More info [here](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation).